### PR TITLE
Coverage sweep: report to codecov; informational statuses

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -25,3 +25,8 @@ jobs:
           channel: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -30,3 +30,6 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          # The org-wide token cannot imply a repository; the slug says
+          # which repo this upload is for.
+          slug: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MadNCL.jl
 
-[![Run tests](https://github.com/MadNLP/MadNCL.jl/actions/workflows/action.yml/badge.svg)](https://github.com/MadNLP/MadNCL.jl/actions/workflows/action.yml)
+[![Run tests](https://github.com/madsuite-org/MadNCL.jl/actions/workflows/action.yml/badge.svg)](https://github.com/madsuite-org/MadNCL.jl/actions/workflows/action.yml)
 
 An implementation of [Algorithm NCL](https://link.springer.com/chapter/10.1007/978-3-319-90026-1_8) in Julia.
 
-MadNCL is built as [MadNLP](https://github.com/MadNLP/MadNLP.jl)'s extension, and supports the solution of
+MadNCL is built as [MadNLP](https://github.com/madsuite-org/MadNLP.jl)'s extension, and supports the solution of
 large-scale nonlinear programs on GPUs. MadNCL is particularly good at solving infeasible
 or degenerate optimization problems.
 
@@ -75,7 +75,7 @@ results = madncl(nlp)
 ## GPU support
 
 MadNCL supports natively the solution of nonlinear programs on the GPU using MadNLPGPU.
-To evaluate your model on the GPU, we recommend using [ExaModels](https://github.com/exanauts/ExaModels.jl).
+To evaluate your model on the GPU, we recommend using [ExaModels](https://github.com/madsuite-org/ExaModels.jl).
 For instance, you can implement the instance `elec` from the [COPS benchmark](https://www.mcs.anl.gov/~more/cops/) directly as:
 
 ```julia

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# Coverage numbers without CI redness: the project/patch checks report their
+# figures but never fail — a coverage drop is information, not a broken build.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Part of the org-wide coverage sweep: the test job gains `julia-processcoverage` + `codecov-action` on the org-level `CODECOV_TOKEN` (the pattern verified across the org this week), `codecov.yml` makes the project/patch statuses informational — numbers and deltas on every PR, never a failed rollup — and README links move off the pre-transfer orgs where the sweep found them. After merge: one codecov-side activation click, then the first CI run posts the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)